### PR TITLE
fix: Adjust splash screen duration to 3 seconds

### DIFF
--- a/script.js
+++ b/script.js
@@ -499,7 +499,7 @@ window.addEventListener('load', () => {
     setTimeout(() => {
       if (splashScreen) splashScreen.classList.add('hidden');
       if (loginSignupScreen) loginSignupScreen.classList.remove('hidden');
-    }, 4000); // Splash screen duration
+    }, 3000); // Splash screen duration
   }
 });
 


### PR DESCRIPTION
I've updated the splash screen display time from 4 seconds to 3 seconds before transitioning to the login/signup page, as per your feedback.