### PR TITLE
feat: Implement ad-based game entry flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,12 +25,22 @@
       <p class="page-subtitle">Login or Sign Up to Play</p>
       <div class="form-container">
         <input type="email" id="emailInput" class="input-field" placeholder="Enter your email" />
-        <button id="loginBtn" class="btn-primary">Login</button>
-        <button id="signupBtn" class="btn-primary">Sign Up</button>
+        <button id="watchAdBtn" class="btn-primary">Watch Ad to Continue</button>
       </div>
       <p id="authMessage" class="auth-message"></p>
     </div>
   </div>
+
+  <!-- Ad Simulation Screen -->
+  <div id="ad-simulation-screen" class="hidden">
+    <div class="ad-content">
+      <h2>Playing Ad</h2>
+      <p>Please wait while the ad finishes...</p>
+      <div id="adTimerDisplay" class="ad-timer">5s</div>
+      <div class="spinner"></div>
+    </div>
+  </div>
+
   <!-- Start Screen -->
   <div id="start-screen" class="center-screen hidden">
     <h1 class="small-title">MEMORY MATCH</h1>

--- a/script.js
+++ b/script.js
@@ -19,6 +19,11 @@ const loginBtn = document.getElementById('loginBtn');
 const signupBtn = document.getElementById('signupBtn');
 const authMessage = document.getElementById('authMessage');
 
+// Ad Simulation Screen Elements
+const adSimulationScreen = document.getElementById('ad-simulation-screen');
+const adTimerDisplay = document.getElementById('adTimerDisplay');
+const watchAdBtn = document.getElementById('watchAdBtn');
+
 const popup = document.getElementById('popup');
 const popupTitle = document.getElementById('popupTitle');
 const popupMessage = document.getElementById('popupMessage');
@@ -418,47 +423,57 @@ function isValidEmail(email) {
 // Function to handle successful login/signup
 function handleSuccessfulAuth(email) {
   localStorage.setItem('userEmail', email); // Store email
-  if (authMessage) authMessage.textContent = 'Success!';
-  if (authMessage) authMessage.style.color = '#d4edda'; // Greenish for success
 
-  // Hide login/signup screen and show main game screen (start-screen)
-  setTimeout(() => {
-    if (loginSignupScreen) loginSignupScreen.classList.add('hidden');
-    if (startScreen) startScreen.classList.remove('hidden');
-    // Potentially load game progress here if that's the desired flow after login
-    // For now, just show the start screen. Saved game state will be checked on load.
-  }, 1000); // Short delay to show success message
+  // No success message needed on authMessage as we are past that screen
+  // if (authMessage) authMessage.textContent = 'Success!';
+  // if (authMessage) authMessage.style.color = '#d4edda';
+
+  // Hide login/signup screen (already hidden) and ad screen (already hidden by timer)
+  // Show main game screen (start-screen)
+  // No timeout needed here as the ad itself was the "delay"
+  if (startScreen) startScreen.classList.remove('hidden');
+
+  // Check for saved game progress (this part is new for this function but uses existing logic)
+  const progress = loadProgress();
+  if (progress) {
+    showResumePopup(progress);
+  }
 }
 
-// Event Listener for Login Button
-if (loginBtn) {
-  loginBtn.addEventListener('click', () => {
+// if (loginBtn) { ... } // Commented out
+// if (signupBtn) { ... } // Commented out
+
+if (watchAdBtn) {
+  watchAdBtn.addEventListener('click', () => {
     const email = emailInput.value.trim();
-    if (!isValidEmail(email)) {
+    if (!isValidEmail(email)) { // isValidEmail function should already exist
       if (authMessage) authMessage.textContent = 'Please enter a valid email address.';
       if (authMessage) authMessage.style.color = '#f8d7da'; // Reddish for error
       return;
     }
-    // For demo purposes, login is always successful if email is valid
-    // In a real app, you'd verify credentials against a backend
-    console.log('Login attempt with:', email);
-    handleSuccessfulAuth(email);
-  });
-}
 
-// Event Listener for Sign Up Button
-if (signupBtn) {
-  signupBtn.addEventListener('click', () => {
-    const email = emailInput.value.trim();
-    if (!isValidEmail(email)) {
-      if (authMessage) authMessage.textContent = 'Please enter a valid email address for signup.';
-      if (authMessage) authMessage.style.color = '#f8d7da'; // Reddish for error
-      return;
-    }
-    // For demo purposes, signup is always successful if email is valid
-    // In a real app, you'd create a new user account with a backend
-    console.log('Signup attempt with:', email);
-    handleSuccessfulAuth(email); // Same handling as login for this demo
+    // Valid email, proceed to ad simulation
+    if (authMessage) authMessage.textContent = ''; // Clear any previous error
+
+    if (loginSignupScreen) loginSignupScreen.classList.add('hidden'); // Hide login form
+    if (adSimulationScreen) adSimulationScreen.classList.remove('hidden'); // Show ad screen
+
+    let adTimeRemaining = 5;
+    if (adTimerDisplay) adTimerDisplay.textContent = adTimeRemaining + 's';
+
+    const adTimerInterval = setInterval(() => {
+      adTimeRemaining--;
+      if (adTimerDisplay) adTimerDisplay.textContent = adTimeRemaining + 's';
+      if (adTimeRemaining <= 0) {
+        clearInterval(adTimerInterval);
+        if (adSimulationScreen) adSimulationScreen.classList.add('hidden');
+
+        // Call the function that handles storing email and showing the main game screen
+        // This function was previously named handleSuccessfulAuth.
+        // Ensure it's defined and does what's needed.
+        handleSuccessfulAuth(email);
+      }
+    }, 1000);
   });
 }
 
@@ -475,6 +490,7 @@ window.addEventListener('load', () => {
     // Hide splash and login screens immediately
     if (splashScreen) splashScreen.classList.add('hidden');
     if (loginSignupScreen) loginSignupScreen.classList.add('hidden');
+    if (adSimulationScreen) adSimulationScreen.classList.add('hidden'); // Ensure ad screen is hidden
 
     // Show the main game screen (start-screen)
     if (startScreen) startScreen.classList.remove('hidden');
@@ -494,6 +510,7 @@ window.addEventListener('load', () => {
     // (HTML defaults should handle this, but good to be sure)
     if (loginSignupScreen) loginSignupScreen.classList.add('hidden');
     if (startScreen) startScreen.classList.add('hidden');
+    if (adSimulationScreen) adSimulationScreen.classList.add('hidden'); // Ensure ad screen is hidden
     if (splashScreen) splashScreen.classList.remove('hidden'); // Make sure splash is visible
 
     setTimeout(() => {

--- a/style.css
+++ b/style.css
@@ -562,3 +562,59 @@ footer {
   color: #ffdddd; /* Light red for error messages, can be changed by JS */
   min-height: 20px; /* Reserve space for messages */
 }
+
+/* Ad Simulation Screen Styles */
+#ad-simulation-screen {
+  display: flex; /* Changed by JS to flex when shown */
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  width: 100vw;
+  background-color: rgba(0, 0, 0, 0.85); /* Dark overlay */
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 2001; /* Highest z-index to cover everything */
+  color: white;
+  text-align: center;
+  padding: 20px;
+}
+
+/* Ensure .hidden correctly hides it */
+#ad-simulation-screen.hidden {
+   display: none;
+}
+
+.ad-content h2 {
+  font-size: 2rem;
+  margin-bottom: 15px;
+}
+
+.ad-content p {
+  font-size: 1.1rem;
+  margin-bottom: 20px;
+}
+
+.ad-timer {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 25px;
+  color: #ffc107; /* Amber color for timer */
+}
+
+/* Basic spinner animation */
+.spinner {
+  border: 6px solid #f3f3f3; /* Light grey */
+  border-top: 6px solid #ff6a00; /* Orange */
+  border-radius: 50%;
+  width: 50px;
+  height: 50px;
+  animation: spin 1s linear infinite;
+  margin: 0 auto; /* Center the spinner */
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}


### PR DESCRIPTION
Revises the initial user experience to include an ad-based interaction on the login/signup screen.

Key changes:

1.  **Splash Screen:**
    *   Displays for 3 seconds on first load or for new users.

2.  **Login/Signup Screen Modification:**
    *   Retains the email input field.
    *   Replaces previous "Login" and "Sign Up" buttons with a single
        "Watch Ad to Continue" button.

3.  **Ad Simulation:**
    *   Clicking "Watch Ad to Continue" (after providing a valid email)
        triggers a 5-second ad simulation screen with a countdown timer.
    *   The game proceeds only after the ad simulation completes.

4.  **Authentication and Data Persistence:**
    *   Your email is stored in `localStorage` *after* the ad simulation
        and before proceeding to the main game screen.
    *   The existing auto-login feature (checking `localStorage` on app
        launch) remains, allowing users with stored data to bypass the
        splash, login, and ad flow, directly entering the main game menu
        (with a resume prompt if saved game progress exists).

5.  **HTML/CSS/JS Updates:**
    *   `index.html`: Updated login screen structure, added ad simulation screen div.
    *   `style.css`: Added styles for the ad simulation screen and ensured
        login screen styles are appropriate.
    *   `script.js`:
        *   Removed old login/signup button logic.
        *   Added event listener and logic for "Watch Ad to Continue" button,
            including email validation and triggering the ad simulation.
        *   Implemented the 5-second ad timer and screen transition.
        *   Updated `handleSuccessfulAuth` to occur post-ad and to integrate
            the resume game check.
        *   Reviewed and confirmed `window.onload` logic for correct handling
            of auto-login and new user splash/login/ad sequence.