### PR TITLE
fix: Improve script robustness to prevent splash screen freeze

### DIFF
--- a/script.js
+++ b/script.js
@@ -479,7 +479,21 @@ if (watchAdBtn) {
 
 // On load check saved progress
 window.addEventListener('load', () => {
-  initAdMob(); // Keep AdMob initialization
+  console.log('Load event triggered.');
+  try {
+    initAdMob();
+  } catch (e) {
+    console.error("Error during initAdMob():", e);
+  }
+
+  // splashScreen and loginSignupScreen are global constants, defined at the top.
+  // Check if they were successfully retrieved from the DOM.
+  if (!splashScreen) {
+    console.error("CRITICAL: splashScreen element is null. Check HTML ID 'splash-screen'.");
+  }
+  if (!loginSignupScreen) {
+    console.error("CRITICAL: loginSignupScreen element is null. Check HTML ID 'login-signup-screen'.");
+  }
 
   const userEmail = localStorage.getItem('userEmail');
   // splashScreen, loginSignupScreen, startScreen are already defined globally
@@ -505,6 +519,7 @@ window.addEventListener('load', () => {
 
   } else {
     // No user email, proceed with splash screen -> login/signup flow:
+    console.log('New user path initiated.');
     console.log('No user email found. Starting splash screen flow.');
     // Ensure login/signup and start screens are hidden, splash is visible initially
     // (HTML defaults should handle this, but good to be sure)
@@ -514,6 +529,9 @@ window.addEventListener('load', () => {
     if (splashScreen) splashScreen.classList.remove('hidden'); // Make sure splash is visible
 
     setTimeout(() => {
+      console.log('Splash timeout reached, attempting to switch screens.');
+      console.log('Splash screen found:', splashScreen);
+      console.log('Login screen found:', loginSignupScreen);
       if (splashScreen) splashScreen.classList.add('hidden');
       if (loginSignupScreen) loginSignupScreen.classList.remove('hidden');
     }, 3000); // Splash screen duration


### PR DESCRIPTION
Addresses an issue where the game could get stuck on the splash screen. The fix includes:
1.  Wrapped the `initAdMob()` call in a `try...catch` block within the `window.onload` event listener. This ensures that any errors occurring during AdMob initialization are caught and logged without halting the rest of the script execution, allowing the splash screen transition logic to proceed.
2.  Added explicit null checks for `splashScreen` and `loginSignupScreen` elements immediately after their definitions in the `window.onload` listener. If these critical elements are not found in the DOM, a console error is logged, providing clearer diagnostics for potential HTML ID mismatches or DOM readiness issues.
3.  Added further `console.log` statements to trace the execution flow during the initial load and splash screen transition, aiding in future debugging.

These changes aim to make the initial loading sequence more resilient to potential errors and improve diagnosability of issues related to screen transitions.