### PR TITLE
fix: Correct footer overlap on start and game screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,7 +17,7 @@ html, body {
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  padding: 10px 0 50px 0;
+  padding: 10px 0 110px 0;
   color: #000;
   user-select: none;
   -webkit-user-select: none;
@@ -52,6 +52,7 @@ h1.small-title {
   justify-content: center;
   height: 100vh;
   width: 100vw;
+  padding-bottom: 60px;
 }
 
 .hidden {


### PR DESCRIPTION
Adjusted CSS to prevent content on the start and game screens from being obscured by or overlapping with the fixed ad banner and footer.

Changes:
- Increased `padding-bottom` on the `html, body` rule from `50px` to `110px`. This provides more space at the bottom of the body's content area to clear the ad banner (approx. 50px high, offset 40px from bottom) and the footer text.
- Added `padding-bottom: 60px;` to the `.center-screen` class. Since elements using this class (like `#start-screen`) often use `height: 100vh` for centering, this additional padding ensures their content is pushed upwards, respecting the newly reserved space for the footer and ad.

These changes ensure all UI elements on the affected screens are fully visible and accessible above the fixed elements at the bottom of the page.