### PR TITLE
Refactor: Update game flow to Splash -> Login (always) -> Game

### DIFF
--- a/script.js
+++ b/script.js
@@ -558,24 +558,24 @@ window.addEventListener('load', () => {
   if (popup) popup.classList.add('hidden');
 
   const proceedWithAppLogic = () => {
-    const userEmail = localStorage.getItem('userEmail');
-    const username = localStorage.getItem('username');
+    console.log('Proceeding to app logic: Unconditionally showing Login/Signup screen.');
 
-    if (username && userEmail) {
-      console.log('User data found. Showing start screen. User:', username);
-      // Ensure login is hidden (splash is already gone or will be)
-      if (loginSignupScreen) loginSignupScreen.classList.add('hidden');
+    // Ensure startScreen and gameScreen are hidden
+    if (startScreen) startScreen.classList.add('hidden');
+    else console.error('CRITICAL: startScreen element not found during proceedWithAppLogic.');
 
-      if (startScreen) startScreen.classList.remove('hidden');
-      const progress = loadProgress();
-      if (progress) {
-        showResumePopup(progress);
-      }
+    if (gameScreen) gameScreen.classList.add('hidden');
+    else console.error('CRITICAL: gameScreen element not found during proceedWithAppLogic.');
+
+    // Ensure resumePopup is hidden
+    if (resumePopup) resumePopup.classList.add('hidden');
+    else console.error('CRITICAL: resumePopup element not found during proceedWithAppLogic.');
+
+    // Show loginSignupScreen
+    if (loginSignupScreen) {
+      loginSignupScreen.classList.remove('hidden');
     } else {
-      console.log('No user data found. Showing login/signup screen.');
-      // Ensure start screen is hidden (splash is already gone or will be)
-      if (startScreen) startScreen.classList.add('hidden');
-      if (loginSignupScreen) loginSignupScreen.classList.remove('hidden');
+      console.error('CRITICAL: loginSignupScreen element not found, cannot display login page.');
     }
   };
 


### PR DESCRIPTION
This implements the requested application flow:
1. The splash screen is displayed for 3 seconds and then removed.
2. The Login/Signup page is unconditionally displayed immediately after the splash screen.
   - The `proceedWithAppLogic` function was modified to always show the `loginSignupScreen` and hide other main game screens at this stage, bypassing previous checks of localStorage for existing sessions.
3. The Game Start screen (or a resume prompt) is displayed only after a successful login or signup action via the `handleSuccessfulAuth` function.
   - The `handleSuccessfulAuth` function was verified to correctly hide the login screen and show the game start screen (plus resume prompt if applicable).

This change ensures a consistent experience for you where the login step is always present after the initial splash, before accessing the game. This also builds upon previous fixes that ensure DOM elements are correctly initialized.