### PR TITLE
Feat: Implement card size, ad banner, and ad link updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <div class="popup-content square popup-zoom">
       <h2>Continue?</h2>
       <button class="btn" id="resumeHomeBtn">Home</button>
-      <button class="btn" id="watchAdResumeBtn">Watch Ad (5s) to Continue</button>
+      <button class="btn" onclick="window.open('https://www.profitableratecpm.com/cbqpeyncv?key=41a7ead40af57cd33ff5f4604f778cb9', '_blank')">Watch Ad (5s) to Continue</button>
       <button class="btn" id="restartFrom1Btn">Restart from Level 1</button>
     </div>
   </div>
@@ -92,7 +92,7 @@
       </div>
       <button class="btn" id="playAgainBtn">Play Again</button>
       <button class="btn" id="loseHomeBtn">Home</button>
-      <button class="btn" id="watchAdBtn">Watch Ad (5s) to Continue</button>
+      <button class="btn" onclick="window.open('https://www.profitableratecpm.com/cbqpeyncv?key=41a7ead40af57cd33ff5f4604f778cb9', '_blank')">Watch Ad (5s) to Continue</button>
     </div>
   </div>
   <!-- Ad Popup -->
@@ -119,6 +119,16 @@
   <!-- New sound for Continue window -->
   <audio id="audio-koni" src="koni.mp3"></audio>
 
+  <script type="text/javascript">
+    atOptions = {
+      'key' : '8a596a14d2ea184cd9b6372e267b931c',
+      'format' : 'iframe',
+      'height' : 50,
+      'width' : 320,
+      'params' : {}
+    };
+  </script>
+  <script type="text/javascript" src="//www.highperformanceformat.com/8a596a14d2ea184cd9b6372e267b931c/invoke.js"></script>
   <footer>
     <span class="powered">Powered by <span>NAS</span></span>
   </footer>

--- a/script.js
+++ b/script.js
@@ -169,15 +169,15 @@ resumeHomeBtn.onclick = () => {
   saveProgress(); // Ensure current progress is saved
   showHome();
 };
-watchAdResumeBtn.onclick = () => {
-  resumePopup.classList.add('hidden');
-  showAd(() => {
-    const progress = JSON.parse(localStorage.getItem('memorymatch_progress'));
-    state.level = progress.level;
-    state.score = progress.score;
-    showGame();
-  });
-};
+// watchAdResumeBtn.onclick = () => {
+//   resumePopup.classList.add('hidden');
+//   showAd(() => {
+//     const progress = JSON.parse(localStorage.getItem('memorymatch_progress'));
+//     state.level = progress.level;
+//     state.score = progress.score;
+//     showGame();
+//   });
+// };
 restartFrom1Btn.onclick = () => {
   stopAllSounds();
   resumePopup.classList.add('hidden');
@@ -435,16 +435,16 @@ loseHomeBtn.onclick = () => {
   saveProgress();
   showHome();
 };
-watchAdBtn.onclick = () => {
-  stopAllSounds();
-  losePopup.classList.add('hidden');
-  showAd(()=>{
-    // +10s reward
-    state.timeLeft += 10;
-    updateHUD();
-    startTimer();
-  });
-};
+// watchAdBtn.onclick = () => {
+//   stopAllSounds();
+//   losePopup.classList.add('hidden');
+//   showAd(()=>{
+//     // +10s reward
+//     state.timeLeft += 10;
+//     updateHUD();
+//     startTimer();
+//   });
+// };
 function updateHUD() {
   levelDisplay.textContent = `Level: ${state.level}`;
   // Ensure time is formatted with leading zero if less than 10
@@ -541,23 +541,28 @@ function shuffle(arr) {
   return a;
 }
 function showAd(callback) {
-  adPopup.classList.remove('hidden');
-  popupSound('pause'); // Play pause sound during ad
-  let t = 5;
-  adTimer.textContent = t;
-  state.adTimeout && clearTimeout(state.adTimeout);
-  function tick() {
-    t--;
-    adTimer.textContent = t;
-    if(t<=0) {
-      adPopup.classList.add('hidden');
-      stopAllSounds(); // Stop pause sound after ad
-      callback && callback();
-    } else {
-      state.adTimeout = setTimeout(tick,1000);
-    }
+  // adPopup.classList.remove('hidden'); // No longer show internal popup
+  // popupSound('pause'); // No longer play internal sound
+  // let t = 5;
+  // adTimer.textContent = t;
+  // state.adTimeout && clearTimeout(state.adTimeout);
+  // function tick() {
+  //   t--;
+  //   adTimer.textContent = t;
+  //   if(t<=0) {
+  //     adPopup.classList.add('hidden');
+  //     stopAllSounds();
+  //     callback && callback(); // Execute callback
+  //   } else {
+  //     state.adTimeout = setTimeout(tick,1000);
+  //   }
+  // }
+  // state.adTimeout = setTimeout(tick,1000);
+
+  // Immediately execute the callback if provided, as ad is external.
+  if (callback) {
+    callback();
   }
-  state.adTimeout = setTimeout(tick,1000);
 }
 
 // Lose/Win/Popup sound only while popup is open

--- a/style.css
+++ b/style.css
@@ -296,8 +296,8 @@ footer span span {
 .card {
   width: 100%; /* Make card fill its grid cell */
   aspect-ratio: 1 / 1; /* Keep it square regardless of width changes */
-  max-width: 130px; /* Larger max size for desktop */
-  max-height: 130px; /* Larger max size for desktop */
+  max-width: 90px; /* Larger max size for desktop */
+  max-height: 90px; /* Larger max size for desktop */
   border: 2px solid black; /* Black border */
   border-radius: 0px;
   display: flex; /* For centering front/back content */
@@ -359,7 +359,7 @@ footer span span {
 }
 
 @media (max-width: 600px) {
-  .card { width: 100%; height: auto; max-width: 90px; max-height: 90px; font-size: 2.2rem; border-radius: 0px;} /* Larger cards on mobile */
+  .card { width: 100%; height: auto; max-width: 70px; max-height: 70px; font-size: 2.2rem; border-radius: 0px;} /* Larger cards on mobile */
   #board { row-gap: 8px; column-gap: 3px; max-width: calc(100vw - 10px); } /* Adjusted gaps and max-width on mobile */
   .splash-card { width: 70px; height: 110px; border-radius: 18px;}
   .game-header h1 { font-size: 1.7rem;}


### PR DESCRIPTION
This commit incorporates several updates based on your feedback:

1.  **Card Size Consistency:**
    - In-game cards in `style.css` are now sized consistently with the splash screen card's width, while remaining square.
    - Desktop cards are 90x90px.
    - Mobile cards (max-width: 600px) are 70x70px.
    - Card border-radius is maintained at 0px for a square appearance.

2.  **Banner Ad Placement:**
    - An Adsterra banner ad script has been added to `index.html`, positioned just above the "Powered by NAS" footer.

3.  **"Watch Ad to Continue" Button Links:**
    - The "Watch Ad (5s) to Continue" buttons in `index.html` (for resuming game and continuing after loss) now open the provided Adsterra URL in a new tab (`_blank`).
    - Associated JavaScript event handlers in `script.js` for these buttons have been removed.
    - The internal `showAd` function in `script.js` has been modified to immediately execute its callback, as the ad display is now handled by an external link. The old internal ad popup logic has been commented out.