### PR TITLE
Feat: Update card size, ad display, and ad button logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
     <div class="popup-content square popup-zoom">
       <h2>Continue?</h2>
       <button class="btn" id="resumeHomeBtn">Home</button>
-      <button class="btn" onclick="window.open('https://www.profitableratecpm.com/cbqpeyncv?key=41a7ead40af57cd33ff5f4604f778cb9', '_blank')">Watch Ad (5s) to Continue</button>
+      <button class="btn" id="watchAdResumeBtn">Watch Ad (5s) to Continue</button>
       <button class="btn" id="restartFrom1Btn">Restart from Level 1</button>
     </div>
   </div>
@@ -92,7 +92,7 @@
       </div>
       <button class="btn" id="playAgainBtn">Play Again</button>
       <button class="btn" id="loseHomeBtn">Home</button>
-      <button class="btn" onclick="window.open('https://www.profitableratecpm.com/cbqpeyncv?key=41a7ead40af57cd33ff5f4604f778cb9', '_blank')">Watch Ad (5s) to Continue</button>
+      <button class="btn" id="watchAdBtn">Watch Ad (5s) to Continue</button>
     </div>
   </div>
   <!-- Ad Popup -->
@@ -119,16 +119,18 @@
   <!-- New sound for Continue window -->
   <audio id="audio-koni" src="koni.mp3"></audio>
 
-  <script type="text/javascript">
-    atOptions = {
-      'key' : '8a596a14d2ea184cd9b6372e267b931c',
-      'format' : 'iframe',
-      'height' : 50,
-      'width' : 320,
-      'params' : {}
-    };
-  </script>
-  <script type="text/javascript" src="//www.highperformanceformat.com/8a596a14d2ea184cd9b6372e267b931c/invoke.js"></script>
+  <div id="bannerAdContainer" style="text-align: center; margin-bottom: 10px; margin-top: 10px; position: relative; z-index: 201;">
+    <script type="text/javascript">
+      atOptions = {
+        'key' : '8a596a14d2ea184cd9b6372e267b931c',
+        'format' : 'iframe',
+        'height' : 50,
+        'width' : 320,
+        'params' : {}
+      };
+    </script>
+    <script type="text/javascript" src="//www.highperformanceformat.com/8a596a14d2ea184cd9b6372e267b931c/invoke.js"></script>
+  </div>
   <footer>
     <span class="powered">Powered by <span>NAS</span></span>
   </footer>

--- a/script.js
+++ b/script.js
@@ -169,15 +169,16 @@ resumeHomeBtn.onclick = () => {
   saveProgress(); // Ensure current progress is saved
   showHome();
 };
-// watchAdResumeBtn.onclick = () => {
-//   resumePopup.classList.add('hidden');
-//   showAd(() => {
-//     const progress = JSON.parse(localStorage.getItem('memorymatch_progress'));
-//     state.level = progress.level;
-//     state.score = progress.score;
-//     showGame();
-//   });
-// };
+watchAdResumeBtn.onclick = () => {
+  window.open('https://www.profitableratecpm.com/cbqpeyncv?key=41a7ead40af57cd33ff5f4604f778cb9', '_blank');
+  resumePopup.classList.add('hidden'); // Hide the resume popup
+  startInGameAdTimer(() => { // Define original callback for resuming
+    const progress = JSON.parse(localStorage.getItem('memorymatch_progress'));
+    state.level = progress.level;
+    state.score = progress.score;
+    showGame(); // This was the original action
+  });
+};
 restartFrom1Btn.onclick = () => {
   stopAllSounds();
   resumePopup.classList.add('hidden');
@@ -227,8 +228,12 @@ function getGridSize(level) {
     const footerHeight = document.querySelector('footer') ? document.querySelector('footer').offsetHeight : 0;
     const availableHeightForBoard = window.innerHeight - headerHeight - statsHeight - footerHeight - 50; // 50px for extra margins/padding
 
-    // Assuming average card size of 80px (for responsive CSS) + 12px row-gap
-    const estimatedCardHeightWithGap = 80 + 12;
+    let estimatedCardHeightWithGap;
+    if (window.innerWidth <= 600) { // Mobile
+        estimatedCardHeightWithGap = 110 + 8; // 110px card height + 8px mobile row-gap
+    } else { // Desktop
+        estimatedCardHeightWithGap = 140 + 12; // 140px card height + 12px desktop row-gap
+    }
     let maxRowsPossible = Math.floor(availableHeightForBoard / estimatedCardHeightWithGap);
     if (maxRowsPossible < 2) maxRowsPossible = 2; // Minimum 2 rows
 
@@ -435,16 +440,13 @@ loseHomeBtn.onclick = () => {
   saveProgress();
   showHome();
 };
-// watchAdBtn.onclick = () => {
-//   stopAllSounds();
-//   losePopup.classList.add('hidden');
-//   showAd(()=>{
-//     // +10s reward
-//     state.timeLeft += 10;
-//     updateHUD();
-//     startTimer();
-//   });
-// };
+watchAdBtn.onclick = () => {
+  window.open('https://www.profitableratecpm.com/cbqpeyncv?key=41a7ead40af57cd33ff5f4604f778cb9', '_blank');
+  losePopup.classList.add('hidden'); // Hide the lose popup
+  startInGameAdTimer(() => { // Define original callback for continuing after loss
+    startTimer();
+  });
+};
 function updateHUD() {
   levelDisplay.textContent = `Level: ${state.level}`;
   // Ensure time is formatted with leading zero if less than 10
@@ -540,30 +542,59 @@ function shuffle(arr) {
   }
   return a;
 }
-function showAd(callback) {
-  // adPopup.classList.remove('hidden'); // No longer show internal popup
-  // popupSound('pause'); // No longer play internal sound
-  // let t = 5;
-  // adTimer.textContent = t;
-  // state.adTimeout && clearTimeout(state.adTimeout);
-  // function tick() {
-  //   t--;
-  //   adTimer.textContent = t;
-  //   if(t<=0) {
-  //     adPopup.classList.add('hidden');
-  //     stopAllSounds();
-  //     callback && callback(); // Execute callback
-  //   } else {
-  //     state.adTimeout = setTimeout(tick,1000);
-  //   }
-  // }
-  // state.adTimeout = setTimeout(tick,1000);
 
-  // Immediately execute the callback if provided, as ad is external.
-  if (callback) {
-    callback();
+function startInGameAdTimer(callback) {
+  adPopup.classList.remove('hidden');
+  popupSound('pause'); // Optional: play a sound when timer starts
+  let secondsLeft = 5;
+  adTimer.textContent = secondsLeft;
+  state.adTimeout && clearTimeout(state.adTimeout); // Clear any existing ad timeout
+
+  function tick() {
+    secondsLeft--;
+    adTimer.textContent = secondsLeft;
+    if (secondsLeft <= 0) {
+      clearTimeout(state.adTimeout); // Use clearTimeout as we're using setTimeout for recursion
+      adPopup.classList.add('hidden');
+      stopAllSounds(); // Stop pause sound
+
+      state.timeLeft += 10; // Add 10 seconds to game timer
+      updateHUD(); // Update timer display
+
+      if (callback) {
+        callback(); // Execute the original game continuation logic
+      }
+    } else {
+      state.adTimeout = setTimeout(tick, 1000);
+    }
   }
+  state.adTimeout = setTimeout(tick, 1000); // Start the timer
 }
+
+// function showAd(callback) {
+//   // adPopup.classList.remove('hidden'); // No longer show internal popup
+//   // popupSound('pause'); // No longer play internal sound
+//   // let t = 5;
+//   // adTimer.textContent = t;
+//   // state.adTimeout && clearTimeout(state.adTimeout);
+//   // function tick() {
+//   //   t--;
+//   //   adTimer.textContent = t;
+//   //   if(t<=0) {
+//   //     adPopup.classList.add('hidden');
+//   //     stopAllSounds();
+//   //     callback && callback(); // Execute callback
+//   //   } else {
+//   //     state.adTimeout = setTimeout(tick,1000);
+//   //   }
+//   // }
+//   // state.adTimeout = setTimeout(tick,1000);
+//
+//   // Immediately execute the callback if provided, as ad is external.
+//   // if (callback) {
+//   //   callback();
+//   // }
+// }
 
 // Lose/Win/Popup sound only while popup is open
 [winPopup, losePopup, adPopup, resumePopup].forEach(popup => {

--- a/style.css
+++ b/style.css
@@ -296,8 +296,8 @@ footer span span {
 .card {
   width: 100%; /* Make card fill its grid cell */
   aspect-ratio: 1 / 1; /* Keep it square regardless of width changes */
-  max-width: 90px; /* Larger max size for desktop */
-  max-height: 90px; /* Larger max size for desktop */
+  max-width: 140px; /* Larger max size for desktop */
+  max-height: 140px; /* Larger max size for desktop */
   border: 2px solid black; /* Black border */
   border-radius: 0px;
   display: flex; /* For centering front/back content */
@@ -359,7 +359,7 @@ footer span span {
 }
 
 @media (max-width: 600px) {
-  .card { width: 100%; height: auto; max-width: 70px; max-height: 70px; font-size: 2.2rem; border-radius: 0px;} /* Larger cards on mobile */
+  .card { width: 100%; height: auto; max-width: 110px; max-height: 110px; font-size: 2.2rem; border-radius: 0px;} /* Larger cards on mobile */
   #board { row-gap: 8px; column-gap: 3px; max-width: calc(100vw - 10px); } /* Adjusted gaps and max-width on mobile */
   .splash-card { width: 70px; height: 110px; border-radius: 18px;}
   .game-header h1 { font-size: 1.7rem;}


### PR DESCRIPTION
This commit implements several enhancements based on your feedback:

1.  **Card Size Update:**
    - In-game cards in `style.css` are now larger, matching the splash screen card's height while remaining square.
    - Desktop cards: 140x140px.
    - Mobile cards (max-width: 600px): 110x110px.
    - The `getGridSize` function in `script.js` has been updated to correctly calculate layout based on these new dimensions, potentially resulting in fewer cards per level.

2.  **Banner Ad Position Fix:**
    - The Adsterra banner ad script in `index.html` has been wrapped in a styled `div` to ensure it is visible and correctly positioned above the footer. Inline styles for centering, margins, and z-index have been applied.

3.  **Enhanced "Watch Ad to Continue" Button Functionality:**
    - Buttons in `index.html` now trigger JavaScript functions instead of directly opening links.
    - In `script.js`, when these buttons are clicked:
        - The specified Adsterra ad link is opened in a new tab.
        - An in-game 5-second timer is started, displayed using the existing ad popup elements. - After 5 seconds, the game resumes, and 10 seconds are added to the level's timer.
    - The `startInGameAdTimer` function was created to handle this new flow, and the old `showAd` function has been removed.