### PR TITLE
Fix: Ensure robust game resume after external ad redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,15 @@
       <button class="btn" id="startBtn">Start</button>
     </div>
   </div>
+  <!-- Resume Popup -->
+  <div id="resumePopup" class="popup hidden">
+    <div class="popup-content square popup-zoom">
+      <h2>Continue?</h2>
+      <button class="btn" id="resumeHomeBtn">Home</button>
+      <button class="btn" id="watchAdResumeBtn">Watch Ad (5s) to Continue</button>
+      <button class="btn" id="restartFrom1Btn">Restart from Level 1</button>
+    </div>
+  </div>
   <!-- Auth -->
   <div id="auth" class="hidden">
     <input type="email" id="email" placeholder="Email">
@@ -84,6 +93,14 @@
       </div>
       <button class="btn" id="playAgainBtn">Play Again</button>
       <button class="btn" id="loseHomeBtn">Home</button>
+      <button class="btn" id="watchAdBtn">Watch Ad (5s) to Continue</button>
+    </div>
+  </div>
+  <!-- Ad Popup -->
+  <div id="adPopup" class="popup hidden">
+    <div class="popup-content square popup-zoom">
+      <h2>Ad</h2>
+      <p>Watching ad... Please wait <span id="adTimer">5</span>s</p>
     </div>
   </div>
   <!-- Sounds -->


### PR DESCRIPTION
This commit enhances the game's ability to resume correctly after you are redirected to an external ad and then return to the game.

Key changes:
- Modified `saveGameState()` to include `state.paused` and `state.awaitingFirstTapAfterAd` in the data saved to localStorage.
- Modified `loadFullGameState()` to correctly restore these states (`paused`, `awaitingFirstTapAfterAd`) and to reconstruct the `state.postAdCallback` if the game is loading into an 'awaiting first tap after ad' state.

This ensures that the game's timer, score, level, card states, and the specific UI state related to ad completion (e.g., 10-second time bonus from `startInGameAdTimer`, requirement to tap to continue) are accurately preserved and restored, even if the game tab is reloaded while you are viewing the external ad.

The game now more reliably behaves as if paused in the background during ad viewing and resumes from the correct point, including applying any ad-related rewards and interactions.