### PR TITLE
Feat: Implement mandatory ad to resume for returning users

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,10 +24,8 @@
   <!-- Resume Popup -->
   <div id="resumePopup" class="popup hidden">
     <div class="popup-content square popup-zoom">
-      <h2>Continue?</h2>
-      <button class="btn" id="resumeHomeBtn">Home</button>
-      <button class="btn" id="watchAdResumeBtn">Watch Ad (5s) to Continue</button>
-      <button class="btn" id="restartFrom1Btn">Restart from Level 1</button>
+      <h2>Resume Previous Game</h2>
+      <button class="btn" id="watchAdResumeBtn">Watch Ad to Resume</button>
     </div>
   </div>
   <!-- Auth -->


### PR DESCRIPTION
This commit modifies the game's startup flow for returning users. If a user has a previously saved game state:
1.  `initializeGame` now always proceeds to the splash/home screen, instead of auto-resuming.
2.  When you click the 'Start' button on the home screen, if a resumable game state exists, a modified 'Resume Previous Game' popup is displayed.
3.  This popup now only offers one option: 'Watch Ad to Resume'. The 'Home' and 'Restart from Level 1' buttons have been removed from this specific popup.
4.  Clicking 'Watch Ad to Resume' triggers the existing rewarded ad flow, after which the game resumes from the saved state (level, score, timer, card layout).

This change ensures that returning users are presented with a mandatory option to watch an ad to continue their saved game each time they launch the game and click start. Event handlers for the removed buttons in the resume popup have also been cleaned up.