### PR TITLE
feat: Implement 'Continue?' popup and enhance ad rewards

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,8 +83,18 @@
         <span id="resultTimeL">Time Left: 0s</span>
       </div>
       <button class="btn" id="playAgainBtn">Play Again</button>
-      <button class="btn" id="loseHomeBtn">Home</button>
-      <button class="btn" id="watchAdBtn">Watch Ad (5s) to Continue</button>
+      <button class="btn" id="loseWatchAdBtn">Watch Ad 5 sec to Continue</button>
+      <button class="btn" id="loseRestartHomeBtn">Home</button>
+      <button class="btn" id="loseStartFromLevel1Btn">Start from Level 1</button>
+    </div>
+  </div>
+  <!-- Continue Popup -->
+  <div id="continuePopup" class="popup hidden">
+    <div class="popup-content square popup-zoom">
+      <h2>Continue?</h2>
+      <button class="btn" id="watchAdContinueBtn">Watch Ad 5 sec to Continue</button>
+      <button class="btn" id="continueHomeBtn">Home</button>
+      <button class="btn" id="startFromLevel1Btn">Start from Level 1</button>
     </div>
   </div>
   <!-- Sounds -->


### PR DESCRIPTION
This commit introduces several new features and improvements to the game flow and your experience:

1.  **"Continue?" Popup on Home Screen:**
    *   When an existing user with a saved game state clicks "Start" on the home screen, a "Continue?" popup is now displayed.
    *   This popup offers three options:
        *   "Watch Ad 5 sec to Continue": Simulates a 5-second ad, then resumes the game from the last saved level with a 10-second time bonus.
        *   "Home": Returns you to the home screen and clears the saved game state, allowing a fresh start.
        *   "Start from Level 1": Resets the game to level 1 and clears any previous progress.

2.  **Updated "Lose" Popup:**
    *   The "You Lost!" popup now features the same three options as the "Continue?" popup:
        *   "Watch Ad 5 sec to Continue": Simulates a 5-second ad, then allows you to retry the current level with a 10-second time bonus.
        *   "Home": Returns to the home screen, clearing the current game state.
        *   "Start from Level 1": Resets the game to level 1.
    *   The previous single "Watch Ad" button and a redundant "Home" button on the lose screen have been replaced by this new system.

3.  **Tap-to-Start Bonus Timer:**
    *   When you receive the 10-second bonus time (after either of the "Watch Ad" options), the game timer does not start automatically.
    *   The timer remains paused until you tap on any card on the game board, providing better control and user experience.

4.  **General Improvements:**
    *   Introduced new DOM elements and JavaScript functions to manage the new popups and their logic.
    *   Refined game state management (`saveGameState`, `loadFullGameState`, `clearFullGameState`) to accommodate the new flows and flags (like `awaitingTapForBonusTime`).
    *   Ensured consistent styling for new UI elements by leveraging existing CSS classes.
    *   Addressed a bug where the "Continue?" popup might briefly show for new users.

These changes aim to improve player retention by offering options to continue gameplay and provide a more engaging ad reward mechanism.