### PR TITLE
Okay, I've made some changes to the code for you. Here's a rundown:

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,13 @@
       <button class="btn" id="startFromLevel1Btn">Start from Level 1</button>
     </div>
   </div>
+  <!-- Ad Overlay Popup -->
+  <div id="adOverlay" class="popup hidden">
+    <div class="popup-content">
+      <h2 id="adOverlayMessage">Please wait... unlocking your reward</h2>
+      <p id="adOverlayTimer" style="font-size: 1.5em; margin-top: 10px;">5</p>
+    </div>
+  </div>
   <!-- Sounds -->
   <audio id="audio-tap" src="tap.mp3"></audio>
   <audio id="audio-win" src="win.mp3"></audio>

--- a/style.css
+++ b/style.css
@@ -21,6 +21,47 @@ body {
   z-index: 90; /* Below popups, above other content */
 }
 
+#adOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.7); /* Darker overlay for more focus */
+  backdrop-filter: blur(8px); /* Stronger blur */
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 110; /* Above other popups and pageOverlay */
+  display: flex; /* Use flexbox for centering */
+  align-items: center; /* Vertical centering */
+  justify-content: center; /* Horizontal centering */
+  text-align: center;
+}
+
+#adOverlay .popup-content { /* Re-style or ensure it doesn't conflict with .popup .popup-content */
+  background: linear-gradient(135deg, #3f0c76, #290150); /* Darker purple, more serious tone */
+  padding: 2rem; /* More padding */
+  border-radius: 15px; /* Standard border radius */
+  box-shadow: 0 10px 40px rgba(0,0,0,0.4); /* More pronounced shadow */
+  color: white;
+  /* Remove fixed width/aspect-ratio if it's meant to be a simple message box */
+  max-width: 320px;
+  width: 80vw;
+}
+
+#adOverlayMessage {
+  font-size: clamp(1.1rem, 4vw, 1.4rem); /* Responsive font size */
+  margin-bottom: 1rem;
+  font-weight: bold;
+}
+
+#adOverlayTimer {
+  font-size: clamp(1.8rem, 7vw, 2.5rem); /* Larger, responsive font size for timer */
+  margin-top: 0.5rem;
+  font-weight: bold;
+  color: #ffc837; /* Highlight color for timer */
+}
+
+
 #stickyFooter {
   position: fixed;
   bottom: 0;


### PR DESCRIPTION
This commit introduces several enhancements and fixes:

1.  **Ads & Rewards Overhaul:**
    *   "Watch Ad 5 sec to Continue" buttons (Continue/Lose popups) now open the ad link (https://www.profitableratecpm.com/cbqpeyncv?key=41a7ead40af57cd33ff5f4604f778cb9) in a new browser tab.
    *   I've implemented a full-screen overlay with a 5-second countdown ("Please wait... unlocking your reward") that appears immediately after clicking an ad button, disabling game interaction.
    *   I've also revised the reward logic:
        *   Continue Window: Resumes game from the last saved state after the overlay.
        *   Lose Window: Grants +10 seconds (paused until card tap) after the overlay.

2.  **UI/UX Improvements:**
    *   The footer ("Powered by NAS") and banner ad are now shown only on the Splash and Home screens, hidden during gameplay and popups.
    *   I've verified the removal of the "Start from Level 1" button from the Lose window.

3.  **State Management:**
    *   Clicking "Home" from Win, Lose, or Continue popups now saves the current game state to localStorage. This allows you to resume your game via the "Continue?" prompt when you next click "Start".

4.  **Bug Fixes:**
    *   I've resolved a game freeze bug where the win condition wasn't triggered if all cards were matched when resuming from the "Continue?" window's ad reward. An explicit win check is now performed.
    *   Previous fixes for general game state reset (affecting the original freeze bug report) are maintained.