### PR TITLE
This message describes a new feature: "Implement custom full-screen r…

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,14 @@
       <p id="adOverlayTimer" style="font-size: 1.5em; margin-top: 10px;">5</p>
     </div>
   </div>
+  <!-- Custom Reward Screen -->
+  <div id="customRewardScreen" class="hidden">
+    <div id="rewardTopLeftContainer">
+      <div id="rewardCountdownTimer">5</div>
+      <button id="rewardBackButton" class="btn hidden">Back</button>
+    </div>
+    <div id="rewardGuaranteedLabel" class="hidden">Reward Guaranteed</div>
+  </div>
   <!-- Sounds -->
   <audio id="audio-tap" src="tap.mp3"></audio>
   <audio id="audio-win" src="win.mp3"></audio>

--- a/style.css
+++ b/style.css
@@ -474,3 +474,60 @@ footer span span {
 
   .game-controls { max-width: 300px; } /* This can remain as a specific mobile constraint */
 }
+
+/* Custom Reward Screen Styles */
+#customRewardScreen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: linear-gradient(135deg, #4a00e0, #8e2de2); /* Purple gradient (reverse of popups) */
+  z-index: 150; /* Higher than other popups/overlays */
+  display: flex;
+  flex-direction: column; /* Or row, depending on main content layout needs */
+  justify-content: space-between; /* For top/bottom alignment of content */
+  align-items: stretch; /* Default, stretches children to fill cross axis */
+  color: white;
+  padding: 20px;
+  box-sizing: border-box;
+}
+
+#rewardTopLeftContainer {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  display: flex; /* To allow items to sit side-by-side if needed, or stack */
+  align-items: center; /* Vertically align items if they are side-by-side */
+}
+
+#rewardCountdownTimer {
+  font-size: 2em;
+  font-weight: bold;
+  padding: 10px;
+  background-color: rgba(0,0,0,0.2);
+  border-radius: 5px;
+  /* Timer will be replaced by back button, so they won't show at the same time in this container */
+}
+
+#rewardBackButton {
+  /* .btn styles are applied via class="btn" in HTML */
+  /* Overrides or specific styles for back button if needed */
+  padding: 10px 20px; /* Example: Specific padding */
+  font-size: 1em;   /* Example: Specific font size */
+  margin: 0; /* Remove default btn margins if it's too much for the corner */
+  /* width: auto; */ /* Override btn width if it's fixed and too large for a corner button */
+  /* max-width: none; */ /* Remove max-width from .btn if needed */
+  /* display: inline-block; */ /* If .btn is block, might need to adjust for corner placement */
+}
+
+#rewardGuaranteedLabel {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  font-size: 1.2em;
+  font-weight: bold;
+  padding: 10px;
+  background-color: rgba(0,0,0,0.2);
+  border-radius: 5px;
+}


### PR DESCRIPTION
…eward sequence."

It replaces the old "Watch Ad 5 sec to Continue" with a new full-screen experience.

Here's how it works:

1.  **New Custom Reward Screen:**
    - When you click "Watch Ad 5 sec to Continue" (from Continue or Lose popups): - A full-screen purple gradient page will appear. - The original popup (Continue/Lose) will be hidden. - You will no longer be taken to an external ad link.

2.  **Screen Features & Flow:**
    - **Top-left:** A 5-second countdown timer will appear immediately.
    - After 5 seconds:
        - The countdown timer will be replaced by a "Back" button in the top-left.
        - **Top-right:** A "Reward Guaranteed" label will appear.
    - **"Back" Button Action:** - Clicking "Back" will hide the reward screen. - You will be rewarded with +10 seconds of game time. - The game will resume at the same level:
            - If from "Continue" popup: The game will unpause directly. - If from "Lose" popup: The game will unpause after you tap a card (the timer will remain paused until then).

3.  **Technical Changes:**
    - I've added new HTML elements for the reward screen (`#customRewardScreen`, `#rewardCountdownTimer`, `#rewardBackButton`, `#rewardGuaranteedLabel`).
    - I've added CSS styles for the new screen and its components.
    - I've implemented a `showCustomRewardScreen(originalContext)` function in JavaScript to manage the new screen's logic, countdown, and context-based reward application.
    - I've updated `watchAdContinueBtn.onclick` and `loseWatchAdBtn.onclick` to trigger this new custom reward screen.