### PR TITLE
I've made a fix to ensure the ad reward is granted reliably when you …

### DIFF
--- a/script.js
+++ b/script.js
@@ -550,11 +550,15 @@ function getUserData() {
   return null;
 }
 
-// ==== AUTO START ====
-window.onload = function() {
-  showSplash();
+// ==== AUTO START / PAGE LOAD HANDLING ====
+window.addEventListener('pageshow', function(event) {
+  // If the page is loading for the first time (not from bfcache), show splash.
+  if (!event.persisted) {
+    showSplash();
+  }
+  // Always check for ad rewards when the page is shown.
   checkAndApplyAdReward();
-};
+});
 // हर बार popup बंद या next level/home पर sound बंद
 function stopSoundOnPopupClose() { stopAllSounds(); }
 [nextLevelBtn, homeBtn1, playAgainBtn, loseHomeBtn].forEach(btn=>{


### PR DESCRIPTION
…return from the ad page.

I changed the event listener for `checkAndApplyAdReward` in `script.js` from `window.onload` to `pageshow`. This ensures that the ad reward logic is triggered consistently when you navigate back from `ad.html`, even when the page is loaded from the browser's back/forward cache (bfcache).

The `showSplash()` function is now also called within the `pageshow` event listener, but only if `event.persisted` is false (i.e., on a fresh page load, not from bfcache), maintaining its original behavior.