### PR TITLE
feat: Implement ad timer, UI layout adjustments, and popup styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -329,7 +329,9 @@ footer .powered span {
   max-width: 440px;
   min-height: 220px;
   box-sizing: border-box;
-  padding-bottom: 30px;
+  margin-top: 15px;
+  padding-bottom: 10px;
+  margin-bottom: 50px;
   transition: height 0.3s;
 }
 
@@ -410,11 +412,11 @@ footer .powered span {
 .popup-content {
   background: linear-gradient(135deg, #a770ef 0%, #7f53ac 100%);
   border-radius: 18px;
-  padding: 1.2rem 0.8rem;
+  padding: 1.5rem; /* Changed for more square shape */
   text-align: center;
   color: #fff;
   min-width: 120px;
-  max-width: 260px;
+  max-width: 220px; /* Made smaller */
   width: 90vw;
   animation: popupZoom 0.38s cubic-bezier(.4,2,.6,1);
 }


### PR DESCRIPTION
This commit introduces several updates to the game:

1.  **Ad Timer and Navigation:**
    - Clicking "Watch Ad 5 Sec to Continue" now starts a 5-second timer using localStorage.
    - You will be navigated to ad.html.
    - Rewards are granted only if you return after 5 seconds. If not, an alert is shown.

2.  **Card Positioning:**
    - The game cards are now positioned below the Score/Time/Level UI.
    - Sufficient spacing has been added to ensure cards do not overlap with the UI above or the "Powered by NAS" footer below. This was achieved via CSS margin adjustments for the #board element.

3.  **Popup Window Styles (Win/Lose):**
    - The "You Win!" and "You Lost!" popup windows have been made slightly smaller and more square in shape through CSS modifications to the .popup-content class (max-width and padding).

These changes address the specific requirements of the issue, enhancing ad functionality and improving UI layout and aesthetics.